### PR TITLE
docs: join instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ in the issues within this repository.
 
 ## How to Join
 
-If you'd like to be listed as a team member, open a PR adding yourself
-to the list below along with a few words on how you are planning
-to contribute to the team's efforts.
+Please refer to the [Team Membership](./GOVERNANCE.md#team-membership) section of the Governance document for information on how to join this working group.
 
 ## Web-Server Frameworks Team Members
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Things which should not be done in this repo:
 - Determine what is/is not a framework
 - Maintain a list of frameworks, framework authors or maintainers
 
+## Joining
+
+We encourage participation from members across the Node.js and JavaScript
+ecosystem. Feel free to join scheduled meetings and participate
+in the issues within this repository.
+
+## How to Join
+
+If you'd like to be listed as a team member, open a PR adding yourself
+to the list below along with a few words on how you are planning
+to contribute to the team's efforts.
+
 ## Web-Server Frameworks Team Members
 
 <!-- ncu-team-sync.team(nodejs/web-server-frameworks) -->


### PR DESCRIPTION
Added a section about joining.  I have not worked before with the `ncu-team sync` tool mentioned in #2, but this process has worked really well in the package maintenance working group.  @MylesBorins is there a good happy medium which would have nice instructions and not require out of band user action?