### PR TITLE
feat: Added automated meeting issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -1,0 +1,44 @@
+## Date/Time
+
+| Timezone | Date/Time |
+|----------|-----------|
+<%= [
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Chicago',
+  'America/New_York',
+  'Europe/London',
+  'Europe/Amsterdam',
+  'Europe/Moscow',
+  'Asia/Kolkata',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Australia/Sydney'
+].map((zone) => {
+  return `| ${zone} | ${date.setZone(zone).toFormat('EEE dd-MMM-yyyy HH:mm (hh:mm a)')} |`
+}).join('\n') %>
+
+Or in your local time:
+* https://www.timeanddate.com/worldclock/?iso=<%= date.toFormat("yyyy-MM-dd'T'HH:mm:ss") %>
+
+## Agenda
+
+Extracted from **<%= agendaLabel %>** labelled issues and pull requests from **<%= owner %>/<%= repo %>** prior to the meeting.
+
+<%= agendaIssues.map((i) => {
+  return `* ${i.title} [#${i.number}](${i.html_url})`
+}).join('\n') %>
+
+## Invited
+
+@nodejs/web-server-frameworks
+
+## Links
+
+* Minutes:
+
+### Joining the meeting
+
+* link for participants: https://zoom.us/j/951032369
+* For those who just want to watch: https://www.youtube.com/c/nodejs+foundation/live
+* youtube admin page: https://www.youtube.com/my_live_events?filter=scheduled

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -1,0 +1,14 @@
+name: Schedule team meetings
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: wesleytodd/meeting-maker@v0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        schedules: '2020-04-02T17:00:00.0Z/P28D,2020-04-16T13:00:00.0Z/P28D'
+        issueTitle: 'Node.js Foundation Web Server Team Meeting <%= date.toFormat("yyyy-MM-dd") %>'
+        agendaLabel: 'web-server-frameworks-agenda'


### PR DESCRIPTION
In an effort to prevent forgetting to create the meeting issue again, I made a little automation.  This should automatically create the meeting issues a week before the meeting.  You can see the action code here: https://github.com/wesleytodd/meeting-maker

@mhdawson I was thinking a bit about the automation you use, and since it requires remembering to run it, I was pretty sure I would forget 😛.  Maybe there are also opportunities to integrate this better into what you have.

Anyone have thoughts on this approach?