### PR TITLE
Schedule all meetings from 5pm to 6pm UTC

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -9,6 +9,6 @@ jobs:
     - uses: wesleytodd/meeting-maker@v0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        schedules: '2020-04-02T17:00:00.0Z/P7D'
+        schedules: '2020-04-02T17:00:00.0Z/P14D'
         issueTitle: 'Node.js Foundation Web Server Team Meeting <%= date.toFormat("yyyy-MM-dd") %>'
         agendaLabel: 'web-server-frameworks-agenda'

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -9,6 +9,6 @@ jobs:
     - uses: wesleytodd/meeting-maker@v0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        schedules: '2020-04-02T17:00:00.0Z/P28D,2020-04-16T13:00:00.0Z/P28D'
+        schedules: '2020-04-02T17:00:00.0Z/P7D'
         issueTitle: 'Node.js Foundation Web Server Team Meeting <%= date.toFormat("yyyy-MM-dd") %>'
         agendaLabel: 'web-server-frameworks-agenda'


### PR DESCRIPTION
It happened [today](https://github.com/nodejs/web-server-frameworks/issues/61) and in the past that the 1pm - 2pm UTC meetings do not have AMER attendees, very likely because of the time.
I'm proposing to do it only at 5pm - 6pm UTC, which seems the one with the most attendance.

What do you think?
@wesleytodd I'm not entirely sure that the `schedules` syntax is correct, please double check it ;)